### PR TITLE
Fix compilation for argument placeholders in comments

### DIFF
--- a/couchbase-entity/src/main/java/com/kaufland/generation/EntityGeneration.kt
+++ b/couchbase-entity/src/main/java/com/kaufland/generation/EntityGeneration.kt
@@ -56,7 +56,7 @@ class EntityGeneration {
                 .addFunction(BuilderClassGeneration.generateBuilderFun())
 
         if (holder.comment.isNotEmpty()) {
-            typeBuilder.addKdoc(holder.comment.joinToString(separator = "\n"))
+            typeBuilder.addKdoc(KDocGeneration.generate(holder.comment))
         }
 
         for (baseModelHolder in holder.basedOn) {

--- a/couchbase-entity/src/main/java/com/kaufland/generation/KDocGeneration.kt
+++ b/couchbase-entity/src/main/java/com/kaufland/generation/KDocGeneration.kt
@@ -1,0 +1,9 @@
+package com.kaufland.generation
+
+import com.squareup.kotlinpoet.CodeBlock
+
+object KDocGeneration {
+    fun generate(comments: Array<String>): CodeBlock {
+        return CodeBlock.of("%L", comments.joinToString(separator = "\n"))
+    }
+}

--- a/couchbase-entity/src/main/java/com/kaufland/generation/WrapperGeneration.kt
+++ b/couchbase-entity/src/main/java/com/kaufland/generation/WrapperGeneration.kt
@@ -29,7 +29,7 @@ class WrapperGeneration {
                 .addFunction(BuilderClassGeneration.generateBuilderFun())
 
         if (holder.comment.isNotEmpty()) {
-            typeBuilder.addKdoc(holder.comment.joinToString(separator = "\n"))
+            typeBuilder.addKdoc(KDocGeneration.generate(holder.comment))
         }
 
         for (baseModelHolder in holder.basedOn) {

--- a/couchbase-entity/src/main/java/com/kaufland/model/field/CblConstantHolder.kt
+++ b/couchbase-entity/src/main/java/com/kaufland/model/field/CblConstantHolder.kt
@@ -1,5 +1,6 @@
 package com.kaufland.model.field
 
+import com.kaufland.generation.KDocGeneration
 import com.kaufland.generation.TypeConversionMethodsGeneration
 import com.kaufland.javaToKotlinType
 import com.kaufland.util.ConversionUtil
@@ -35,7 +36,7 @@ class CblConstantHolder(field: Field) : CblBaseFieldHolder(field.name, field) {
                 .getter(FunSpec.getterBuilder().addStatement("return " + TypeConversionMethodsGeneration.READ_METHOD_NAME + "(mDoc.get(%N), %T::class)!!", constantName, returnType).build())
 
         if (comment.isNotEmpty()) {
-            builder.addKdoc(comment.joinToString(separator = "\n"))
+            builder.addKdoc(KDocGeneration.generate(comment))
         }
 
         return builder.build()

--- a/couchbase-entity/src/main/java/com/kaufland/model/field/CblFieldHolder.kt
+++ b/couchbase-entity/src/main/java/com/kaufland/model/field/CblFieldHolder.kt
@@ -1,5 +1,6 @@
 package com.kaufland.model.field
 
+import com.kaufland.generation.KDocGeneration
 import com.kaufland.generation.TypeConversionMethodsGeneration
 import com.kaufland.util.TypeUtil
 import com.squareup.kotlinpoet.*
@@ -90,7 +91,7 @@ class CblFieldHolder(field: Field, allWrappers: List<String>) : CblBaseFieldHold
         }
 
         if (comment.isNotEmpty()) {
-            propertyBuilder.addKdoc(comment.joinToString(separator = "\n"))
+            propertyBuilder.addKdoc(KDocGeneration.generate(comment))
         }
 
         return propertyBuilder.setter(setter.build()).getter(getter.build()).build()
@@ -109,7 +110,7 @@ class CblFieldHolder(field: Field, allWrappers: List<String>) : CblBaseFieldHold
                 .returns(ClassName(packageName, "${entitySimpleName}.Builder"))
 
         if (this.comment.isNotEmpty()) {
-            builder.addKdoc(this.comment.joinToString(separator = "\n"))
+            builder.addKdoc(KDocGeneration.generate(comment))
         }
 
         builder.addStatement("obj.${accessorSuffix()} = value")

--- a/couchbase-entity/src/test/java/com/kaufland/generation/KDocGenerationTest.kt
+++ b/couchbase-entity/src/test/java/com/kaufland/generation/KDocGenerationTest.kt
@@ -1,0 +1,11 @@
+package com.kaufland.generation
+
+import org.junit.Test
+
+class KDocGenerationTest {
+
+    @Test
+    fun `generateKDoc should not throw exception for formatting placeholders`() {
+        KDocGeneration.generate(arrayOf("%1D"))
+    }
+}

--- a/demo/src/main/java/kaufland/com/demo/entity/Product.kt
+++ b/demo/src/main/java/kaufland/com/demo/entity/Product.kt
@@ -11,7 +11,7 @@ import kaufland.com.coachbasebinderapi.query.Query
 @Fields(
         Field(name = "type", type = String::class, defaultValue = "product", readonly = true, comment = ["Document type"]),
         Field(name = "name", type = String::class, comment = ["contains the product name.", "and other infos"]),
-        Field(name = "comments", type = UserComment::class, list = true),
+        Field(name = "comments", type = UserComment::class, list = true, comment = ["I'm also comfortable with pseudo %2D placeholders"]),
         Field(name = "image", type = Blob::class),
         Field(name = "identifiers", type = String::class, list = true)
 )


### PR DESCRIPTION
Fix for special chars in url encoded links that may be used in comments: https://www.google.com/search?q=%28