### PR TITLE
Fix: generated classes can include a class without import

### DIFF
--- a/couchbase-entity/src/main/java/com/kaufland/model/EntityFactory.kt
+++ b/couchbase-entity/src/main/java/com/kaufland/model/EntityFactory.kt
@@ -56,7 +56,7 @@ object EntityFactory {
 
         parseStaticsFromStructure(cblEntityElement) {
             if (it.getAnnotation(GenerateAccessor::class.java) != null) {
-                content.generateAccessors.add(CblGenerateAccessorHolder(content.sourceClazzSimpleName, it))
+                content.generateAccessors.add(CblGenerateAccessorHolder(content.sourceClazzTypeName, it))
             }
             it.getAnnotation(DocIdSegment::class.java)?.apply {
                 docIdSegments.add(DocIdSegmentHolder(this, it))

--- a/couchbase-entity/src/main/java/com/kaufland/model/entity/BaseEntityHolder.kt
+++ b/couchbase-entity/src/main/java/com/kaufland/model/entity/BaseEntityHolder.kt
@@ -49,6 +49,9 @@ abstract class BaseEntityHolder {
     val sourceClazzSimpleName: String
         get() = (sourceElement as Symbol.ClassSymbol).simpleName.toString()
 
+    val sourceClazzTypeName: TypeName
+        get() = ClassName(`package`, sourceClazzSimpleName)
+
     open val entitySimpleName: String
         get() = sourceClazzSimpleName + "Entity"
 

--- a/demo/src/main/java/kaufland/com/demo/mapper/DummyMapperSource.kt
+++ b/demo/src/main/java/kaufland/com/demo/mapper/DummyMapperSource.kt
@@ -5,7 +5,6 @@ import kaufland.com.coachbasebinderapi.mapify.Mapify
 import kaufland.com.coachbasebinderapi.mapify.Mapifyable
 import kaufland.com.coachbasebinderapi.mapify.Mapper
 import kaufland.com.demo.entity.ProductEntity
-import kaufland.com.demo.entity.TestClass
 import java.io.Serializable
 import java.math.BigDecimal
 


### PR DESCRIPTION
Add sourceClazzTypeName on BaseEntityHolder
Update CblGenerateAccessorHolder not to use String name but Type of class