### PR TITLE
Feature/limit query results

### DIFF
--- a/couchbase-entity-api/src/main/java/kaufland/com/coachbasebinderapi/PersistenceConfig.kt
+++ b/couchbase-entity-api/src/main/java/kaufland/com/coachbasebinderapi/PersistenceConfig.kt
@@ -2,6 +2,8 @@ package kaufland.com.coachbasebinderapi
 
 import kotlin.reflect.KClass
 
+private const val DEFAULT_LIMIT = 1000
+
 object PersistenceConfig {
     private var mConnector: Connector? = null
     private var mSuspendingConnector: SuspendingConnector? = null
@@ -10,7 +12,7 @@ object PersistenceConfig {
         val typeConversions: Map<KClass<*>, TypeConversion>
         fun getDocument(id: String, dbName: String): Map<String, Any>?
         fun getDocuments(ids: List<String>, dbName: String): List<Map<String, Any>?>
-        fun queryDoc(dbName: String, queryParams: Map<String, Any>): List<Map<String, Any>>
+        fun queryDoc(dbName: String, queryParams: Map<String, Any>, limit: Int = DEFAULT_LIMIT): List<Map<String, Any>>
 
         @Throws(PersistenceException::class)
         fun deleteDocument(id: String, dbName: String)
@@ -27,7 +29,7 @@ object PersistenceConfig {
 
         suspend fun getDocuments(ids: List<String>, dbName: String): List<Map<String, Any>>
 
-        suspend fun queryDoc(dbName: String, queryParams: Map<String, Any>): List<Map<String, Any>>
+        suspend fun queryDoc(dbName: String, queryParams: Map<String, Any>, limit: Int = DEFAULT_LIMIT): List<Map<String, Any>>
 
         @Throws(PersistenceException::class)
         suspend fun deleteDocument(id: String, dbName: String)

--- a/couchbase-entity-api/src/main/java/kaufland/com/coachbasebinderapi/PersistenceConfig.kt
+++ b/couchbase-entity-api/src/main/java/kaufland/com/coachbasebinderapi/PersistenceConfig.kt
@@ -2,7 +2,6 @@ package kaufland.com.coachbasebinderapi
 
 import kotlin.reflect.KClass
 
-
 object PersistenceConfig {
     private var mConnector: Connector? = null
     private var mSuspendingConnector: SuspendingConnector? = null

--- a/couchbase-entity-api/src/main/java/kaufland/com/coachbasebinderapi/PersistenceConfig.kt
+++ b/couchbase-entity-api/src/main/java/kaufland/com/coachbasebinderapi/PersistenceConfig.kt
@@ -2,7 +2,6 @@ package kaufland.com.coachbasebinderapi
 
 import kotlin.reflect.KClass
 
-private const val DEFAULT_LIMIT = 1000
 
 object PersistenceConfig {
     private var mConnector: Connector? = null
@@ -12,7 +11,7 @@ object PersistenceConfig {
         val typeConversions: Map<KClass<*>, TypeConversion>
         fun getDocument(id: String, dbName: String): Map<String, Any>?
         fun getDocuments(ids: List<String>, dbName: String): List<Map<String, Any>?>
-        fun queryDoc(dbName: String, queryParams: Map<String, Any>, limit: Int = DEFAULT_LIMIT): List<Map<String, Any>>
+        fun queryDoc(dbName: String, queryParams: Map<String, Any>, limit: Int? = null): List<Map<String, Any>>
 
         @Throws(PersistenceException::class)
         fun deleteDocument(id: String, dbName: String)
@@ -29,7 +28,7 @@ object PersistenceConfig {
 
         suspend fun getDocuments(ids: List<String>, dbName: String): List<Map<String, Any>>
 
-        suspend fun queryDoc(dbName: String, queryParams: Map<String, Any>, limit: Int = DEFAULT_LIMIT): List<Map<String, Any>>
+        suspend fun queryDoc(dbName: String, queryParams: Map<String, Any>, limit: Int? = null): List<Map<String, Any>>
 
         @Throws(PersistenceException::class)
         suspend fun deleteDocument(id: String, dbName: String)

--- a/couchbase-entity-connector/src/main/java/kaufland/com/couchbaseentityconnector/Couchbase2Connector.kt
+++ b/couchbase-entity-connector/src/main/java/kaufland/com/couchbaseentityconnector/Couchbase2Connector.kt
@@ -88,7 +88,7 @@ abstract class Couchbase2Connector : PersistenceConfig.Connector {
     }
 
     @Throws(PersistenceException::class)
-    override fun queryDoc(dbName: String, queryParams: Map<String, Any>): List<Map<String, Any>> {
+    override fun queryDoc(dbName: String, queryParams: Map<String, Any>, limit: Int): List<Map<String, Any>> {
         try {
 
             val builder = QueryBuilder.select(SelectResult.expression(Meta.id), SelectResult.all())
@@ -97,6 +97,8 @@ abstract class Couchbase2Connector : PersistenceConfig.Connector {
             parseExpressions(queryParams)?.let {
                 builder.where(it)
             }
+
+            builder.limit(Expression.intValue(limit))
 
             return queryResultToMap(builder.execute())
         } catch (e: CouchbaseLiteException) {

--- a/couchbase-entity-connector/src/main/java/kaufland/com/couchbaseentityconnector/Couchbase2Connector.kt
+++ b/couchbase-entity-connector/src/main/java/kaufland/com/couchbaseentityconnector/Couchbase2Connector.kt
@@ -88,7 +88,7 @@ abstract class Couchbase2Connector : PersistenceConfig.Connector {
     }
 
     @Throws(PersistenceException::class)
-    override fun queryDoc(dbName: String, queryParams: Map<String, Any>, limit: Int): List<Map<String, Any>> {
+    override fun queryDoc(dbName: String, queryParams: Map<String, Any>, limit: Int?): List<Map<String, Any>> {
         try {
 
             val builder = QueryBuilder.select(SelectResult.expression(Meta.id), SelectResult.all())
@@ -98,7 +98,7 @@ abstract class Couchbase2Connector : PersistenceConfig.Connector {
                 builder.where(it)
             }
 
-            builder.limit(Expression.intValue(limit))
+            limit?.let { builder.limit(Expression.intValue(limit)) }
 
             return queryResultToMap(builder.execute())
         } catch (e: CouchbaseLiteException) {

--- a/demo/src/test/java/kaufland/com/demo/TypeConversionTest.kt
+++ b/demo/src/test/java/kaufland/com/demo/TypeConversionTest.kt
@@ -35,7 +35,7 @@ class TypeConversionTest {
                 TODO("Not yet implemented")
             }
 
-            override fun queryDoc(dbName: String, queryParams: Map<String, Any>, limit: Int): List<Map<String, Any>> {
+            override fun queryDoc(dbName: String, queryParams: Map<String, Any>, limit: Int?): List<Map<String, Any>> {
                 throw Exception("should not called")
             }
 

--- a/demo/src/test/java/kaufland/com/demo/TypeConversionTest.kt
+++ b/demo/src/test/java/kaufland/com/demo/TypeConversionTest.kt
@@ -35,7 +35,7 @@ class TypeConversionTest {
                 TODO("Not yet implemented")
             }
 
-            override fun queryDoc(dbName: String, queryParams: Map<String, Any>): List<Map<String, Any>> {
+            override fun queryDoc(dbName: String, queryParams: Map<String, Any>, limit: Int): List<Map<String, Any>> {
                 throw Exception("should not called")
             }
 
@@ -43,7 +43,7 @@ class TypeConversionTest {
                 throw Exception("should not called")
             }
 
-            override fun upsertDocument(document: MutableMap<String, Any>, id: String?, dbName: String) {
+            override fun upsertDocument(document: MutableMap<String, Any>, id: String?, dbName: String): Map<String, Any> {
                 throw Exception("should not called")
             }
         })

--- a/demo/src/test/java/kaufland/com/demo/entity/ProductWrapperTest.kt
+++ b/demo/src/test/java/kaufland/com/demo/entity/ProductWrapperTest.kt
@@ -23,7 +23,7 @@ class ProductWrapperTest {
                     TODO("Not yet implemented")
                 }
 
-                override fun queryDoc(dbName: String, queryParams: Map<String, Any>, limit: Int): List<Map<String, Any>> {
+                override fun queryDoc(dbName: String, queryParams: Map<String, Any>, limit: Int?): List<Map<String, Any>> {
                     TODO("Not yet implemented")
                 }
 

--- a/demo/src/test/java/kaufland/com/demo/entity/ProductWrapperTest.kt
+++ b/demo/src/test/java/kaufland/com/demo/entity/ProductWrapperTest.kt
@@ -23,7 +23,7 @@ class ProductWrapperTest {
                     TODO("Not yet implemented")
                 }
 
-                override fun queryDoc(dbName: String, queryParams: Map<String, Any>): List<Map<String, Any>> {
+                override fun queryDoc(dbName: String, queryParams: Map<String, Any>, limit: Int): List<Map<String, Any>> {
                     TODO("Not yet implemented")
                 }
 
@@ -31,7 +31,7 @@ class ProductWrapperTest {
                     TODO("Not yet implemented")
                 }
 
-                override fun upsertDocument(document: MutableMap<String, Any>, id: String?, dbName: String) {
+                override fun upsertDocument(document: MutableMap<String, Any>, id: String?, dbName: String): Map<String, Any> {
                     TODO("Not yet implemented")
                 }
             })

--- a/demo/src/test/java/kaufland/com/demo/mapper/DummyMapperSourceTest.kt
+++ b/demo/src/test/java/kaufland/com/demo/mapper/DummyMapperSourceTest.kt
@@ -25,7 +25,7 @@ class DummyMapperSourceTest {
                 TODO("Not yet implemented")
             }
 
-            override fun queryDoc(dbName: String, queryParams: Map<String, Any>): List<Map<String, Any>> {
+            override fun queryDoc(dbName: String, queryParams: Map<String, Any>, limit: Int): List<Map<String, Any>> {
                 return emptyList()
             }
 
@@ -33,8 +33,8 @@ class DummyMapperSourceTest {
                 // nope
             }
 
-            override fun upsertDocument(document: MutableMap<String, Any>, id: String?, dbName: String) {
-                // nope
+            override fun upsertDocument(document: MutableMap<String, Any>, id: String?, dbName: String): Map<String, Any> {
+                TODO("Not yet implemented")
             }
         })
     }
@@ -68,7 +68,8 @@ class DummyMapperSourceTest {
             assertEquals("oldValue", newObj.innerObject.myString)
             assertEquals("oldValue", newObj.innerObjectList[0].myString)
             assertEquals("oldValue", newObj.innerObjectMap["test"]!!.myString)
-            assertEquals("myLiveVal", newObj.liveData.exposedVal)
+            assertEquals("myLiveVal", newObj.liveData.exposedVal!!.test1)
+            assertEquals(1, newObj.liveData.exposedVal!!.test2)
             assertEquals(2, newObj.nullableList.size)
             assertEquals(null, newObj.nullableList[0])
         }

--- a/demo/src/test/java/kaufland/com/demo/mapper/DummyMapperSourceTest.kt
+++ b/demo/src/test/java/kaufland/com/demo/mapper/DummyMapperSourceTest.kt
@@ -25,7 +25,7 @@ class DummyMapperSourceTest {
                 TODO("Not yet implemented")
             }
 
-            override fun queryDoc(dbName: String, queryParams: Map<String, Any>, limit: Int): List<Map<String, Any>> {
+            override fun queryDoc(dbName: String, queryParams: Map<String, Any>, limit: Int?): List<Map<String, Any>> {
                 return emptyList()
             }
 


### PR DESCRIPTION
Add a new limit parameter to queryDoc in PersistenceConfig to allow limiting the number of results.